### PR TITLE
Feature: webkit-dependent code for clip-path tags for backward compatibility

### DIFF
--- a/theme/crosscode/theme.css
+++ b/theme/crosscode/theme.css
@@ -90,6 +90,7 @@ body {
   position: relative;
   color: #fff;
   background: rgba(0, 0, 0, 0.5);
+  -webkit-clip-path: polygon(0 0.5rem, 0 100%, 100% 100%, 100% 0, 0.5rem 0);
   clip-path: polygon(0 0.5rem, 0 100%, 100% 100%, 100% 0, 0.5rem 0);
   text-shadow: 0.05rem 0.05rem 0.1rem rgba(0, 0, 0, 1);
   padding-top: 0.001rem; /* cheer margin-top workaround */
@@ -128,6 +129,7 @@ body {
   background: #aaa;
   color: #ffe800;
   animation: blinking-text 1s infinite alternate ease;
+  -webkit-clip-path: polygon(0 0.5rem, 0 100%, 100% 100%, 100% 0, 0.5rem 0);
   clip-path: polygon(0 0.5rem, 0 100%, 100% 100%, 100% 0, 0.5rem 0);
 }    
 .chat_cheer_text {

--- a/theme/lobotomy/theme.css
+++ b/theme/lobotomy/theme.css
@@ -46,6 +46,7 @@ body {
   width: 100%;
   background: rgba(0, 0, 0, 0.66);
   overflow: hidden;
+  -webkit-clip-path: polygon(4rem 0, 100% 0, 100% 100%, 0 100%, 0 1.0625rem);
   clip-path: polygon(4rem 0, 100% 0, 100% 100%, 0 100%, 0 1.0625rem);
 }
 /* Nickname / Badge */

--- a/theme/splatoon/theme.css
+++ b/theme/splatoon/theme.css
@@ -82,7 +82,15 @@ html								{	font-family: 'cwtexyen', 'Hanna', sans-serif;
 
 
 /* 박스 디테일 */
-.chat_outer_box 					{	clip-path: polygon(
+.chat_outer_box 					{	-webkit-clip-path: polygon(
+																	0 100%, 100% 100%, 100% 0, 0 0,
+																	0 30px, 2px 34px, 15px 40px, 18px 44px,
+																	18px 54px, 16.5px 57px,
+																	12px 59px, 9px 59px, 8px 57px,
+																	8px 54.5px, 9px 53px, 10.5px 52px,
+																	12px 50px, 12px 49px, 8.5px 46px, 7px 45.5px,
+																	3px 48px, 0 52px, 0 0);
+										clip-path: polygon(
 															0 100%, 100% 100%, 100% 0, 0 0,
 															0 30px, 2px 34px, 15px 40px, 18px 44px,
 															18px 54px, 16.5px 57px,
@@ -96,6 +104,13 @@ html								{	font-family: 'cwtexyen', 'Hanna', sans-serif;
 														display:block; position:absolute;
 														top:0; bottom:0; left:0; right:0; }
 .chat_outer_box::before		{	background:rgba(0,0,0,.8);
+														-webkit-clip-path: polygon(
+															18px 54px, 8px 60px,
+															6px 59px, 6px 56px, 6px 53.5px,
+															7px 52px, 8.5px 51px,
+															10px 49px, 3px 43px, 0 35px,
+															15px 100%, 100% calc(100% - 4px),
+															100% 100%, 15px 100%, 0 35px);
 														clip-path: polygon(
 															18px 54px, 8px 60px,
 															6px 59px, 6px 56px, 6px 53.5px,
@@ -104,6 +119,11 @@ html								{	font-family: 'cwtexyen', 'Hanna', sans-serif;
 															15px 100%, 100% calc(100% - 4px),
 															100% 100%, 15px 100%, 0 35px); }
 .chat_outer_box::after 		{	background:rgba(0,0,0,.25);
+														-webkit-clip-path: polygon(
+															100% 2px, 100% 0,
+															12px 0, 8px 2px, 4px 6px, 2px 10px,
+															0 calc(100% - 10px), 2px calc(100% - 4px), 10px 100%,
+															100% 100%);
 														clip-path: polygon(
 															100% 2px, 100% 0,
 															12px 0, 8px 2px, 4px 6px, 2px 10px,


### PR DESCRIPTION
Added -webkit-clip-path tags for backward compatibility, since old webkit engines does not support clip-path tag.
e.g)
<img width="362" alt="image" src="https://user-images.githubusercontent.com/2904494/36300391-8881799a-1344-11e8-81b5-b63d24266502.png">
This page is far different from original implementation, since chromium engine bundled in electron does not support clip-path tag.
This can be solved by,
<img width="362" alt="image" src="https://user-images.githubusercontent.com/2904494/36300476-daa86ef4-1344-11e8-8820-d7d394cd694a.png">
replacing clip-path tags to -webkit-clip-path .