### PR TITLE
convert inline svg properties to base64 encoding

### DIFF
--- a/theme/celeste/theme.css
+++ b/theme/celeste/theme.css
@@ -36,7 +36,8 @@ body {
 
   border: 0.5rem solid #fff;
   border-right: none;
-  border-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M9,1h18v22h-18l-8,-8v-6z" stroke-width="2" fill="#fff" stroke="#000"/></svg>') 45% stretch;
+  /* border-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M9,1h18v22h-18l-8,-8v-6z" stroke-width="2" fill="#fff" stroke="#000"/></svg>') 45% stretch; */
+  border-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCI+PHBhdGggZD0iTTksMWgxOHYyMmgtMThsLTgsLTh2LTZ6IiBzdHJva2Utd2lkdGg9IjIiIGZpbGw9IiNmZmYiIHN0cm9rZT0iIzAwMCIvPjwvc3ZnPg==') 45% stretch;
 
   background: linear-gradient(to bottom,
     #f0f0f0 0.125rem,

--- a/theme/copious/theme.css
+++ b/theme/copious/theme.css
@@ -65,7 +65,8 @@ body {
 .chat_upper_box {
   display: flex;
   position: relative;
-  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="170" height="36"><path fill="none" stroke="#aaa" d="M107.3,18l9,18z"/><path fill="none" stroke="#fff" d="M35,19l14,3l23-9l35,6l20-10l2-9"/><path fill="#fff" d="M32.5,19l2.5,2.5l2.5-2.5L35,16.5L32.5,19z M45.5,22l3.5,3.5l3.5-3.5L49,18.5L45.5,22z M69.5,13l2.5,2.5l2.5-2.5L72,10.5L69.5,13z M102.5,18l4.5,4.5l4.5-4.5l-4.5-4.5L102.5,18z M123.5,9l3.5,3.5l3.5-3.5L127,5.5L123.5,9zM17,9.5l2.5,2.5L22,9.5L19.5,7L17,9.5z"/></svg>'),
+  /* background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="170" height="36"><path fill="none" stroke="#aaa" d="M107.3,18l9,18z"/><path fill="none" stroke="#fff" d="M35,19l14,3l23-9l35,6l20-10l2-9"/><path fill="#fff" d="M32.5,19l2.5,2.5l2.5-2.5L35,16.5L32.5,19z M45.5,22l3.5,3.5l3.5-3.5L49,18.5L45.5,22z M69.5,13l2.5,2.5l2.5-2.5L72,10.5L69.5,13z M102.5,18l4.5,4.5l4.5-4.5l-4.5-4.5L102.5,18z M123.5,9l3.5,3.5l3.5-3.5L127,5.5L123.5,9zM17,9.5l2.5,2.5L22,9.5L19.5,7L17,9.5z"/></svg>'), */
+  background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNzAiIGhlaWdodD0iMzYiPjxwYXRoIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2FhYSIgZD0iTTEwNy4zLDE4bDksMTh6Ii8+PHBhdGggZmlsbD0ibm9uZSIgc3Ryb2tlPSIjZmZmIiBkPSJNMzUsMTlsMTQsM2wyMy05bDM1LDZsMjAtMTBsMi05Ii8+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTMyLjUsMTlsMi41LDIuNWwyLjUtMi41TDM1LDE2LjVMMzIuNSwxOXogTTQ1LjUsMjJsMy41LDMuNWwzLjUtMy41TDQ5LDE4LjVMNDUuNSwyMnogTTY5LjUsMTNsMi41LDIuNWwyLjUtMi41TDcyLDEwLjVMNjkuNSwxM3ogTTEwMi41LDE4bDQuNSw0LjVsNC41LTQuNWwtNC41LTQuNUwxMDIuNSwxOHogTTEyMy41LDlsMy41LDMuNWwzLjUtMy41TDEyNyw1LjVMMTIzLjUsOXpNMTcsOS41bDIuNSwyLjVMMjIsOS41TDE5LjUsN0wxNyw5LjV6Ii8+PC9zdmc+'),
   linear-gradient(
     to bottom,
     rgba(12, 21, 47, 0.9),
@@ -83,7 +84,8 @@ body {
   right: 0;
   width: 11.5rem;
   height: 2.25rem;
-  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="170" height="36"><polyline fill="none" stroke="#ccc" points="86.3,28 121.3,11 116.3,0"/><path fill="#ccc" d="M118.5,11l2.5,2.5l2.5-2.5L121,8.5L118.5,11z M83.5,28l2.5,2.5l2.5-2.5L86,25.5L83.5,28z M72,8l4,4l4-4l-4-4L72,8z"/></svg>');
+  /* background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="170" height="36"><polyline fill="none" stroke="#ccc" points="86.3,28 121.3,11 116.3,0"/><path fill="#ccc" d="M118.5,11l2.5,2.5l2.5-2.5L121,8.5L118.5,11z M83.5,28l2.5,2.5l2.5-2.5L86,25.5L83.5,28z M72,8l4,4l4-4l-4-4L72,8z"/></svg>'); */
+  background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNzAiIGhlaWdodD0iMzYiPjxwb2x5bGluZSBmaWxsPSJub25lIiBzdHJva2U9IiNjY2MiIHBvaW50cz0iODYuMywyOCAxMjEuMywxMSAxMTYuMywwIi8+PHBhdGggZmlsbD0iI2NjYyIgZD0iTTExOC41LDExbDIuNSwyLjVsMi41LTIuNUwxMjEsOC41TDExOC41LDExeiBNODMuNSwyOGwyLjUsMi41bDIuNS0yLjVMODYsMjUuNUw4My41LDI4eiBNNzIsOGw0LDRsNC00bC00LTRMNzIsOHoiLz48L3N2Zz4=');
   background-position: right top;
   background-repeat: no-repeat;
   mix-blend-mode: hard-light;
@@ -303,7 +305,8 @@ body {
   padding: 0;
   height: 10rem;
 
-  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="320" height="160"><path fill="none" stroke="#FFFFFF" d="M296,54l-32,13l-19,55l-54,13l-27-16 M28.7,32l106,23"/><polygon fill="#FC6D51" points="29.2,35.5 32.7,32 29.2,28.5 25.7,32"/><path fill="#fff" d="M191,132.5l-2.5,2.5l2.5,2.5l2.5-2.5L191,132.5z M164,115.5l-3.5,3.5l3.5,3.5l3.5-3.5L164,115.5zM296,51.5l-2.5,2.5l2.5,2.5l2.5-2.5L296,51.5z M264,62.5l-4.5,4.5l4.5,4.5l4.5-4.5L264,62.5z M245,118.5l-3.5,3.5l3.5,3.5l3.5-3.5L245,118.5z M134.7,57.5l2.5-2.5l-2.5-2.5l-2.5,2.5L134.7,57.5z M78.2,128l2.5,2.5l2.5-2.5l-2.5-2.5L78.2,128z M208.2,68l2.5,2.5l2.5-2.5l-2.5-2.5L208.2,68z M25.2,106l2.5,2.5l2.5-2.5l-2.5-2.5L25.2,106z M295.2,151l2.5,2.5l2.5-2.5l-2.5-2.5L295.2,151z"/></svg>'),
+  /* background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="320" height="160"><path fill="none" stroke="#FFFFFF" d="M296,54l-32,13l-19,55l-54,13l-27-16 M28.7,32l106,23"/><polygon fill="#FC6D51" points="29.2,35.5 32.7,32 29.2,28.5 25.7,32"/><path fill="#fff" d="M191,132.5l-2.5,2.5l2.5,2.5l2.5-2.5L191,132.5z M164,115.5l-3.5,3.5l3.5,3.5l3.5-3.5L164,115.5zM296,51.5l-2.5,2.5l2.5,2.5l2.5-2.5L296,51.5z M264,62.5l-4.5,4.5l4.5,4.5l4.5-4.5L264,62.5z M245,118.5l-3.5,3.5l3.5,3.5l3.5-3.5L245,118.5z M134.7,57.5l2.5-2.5l-2.5-2.5l-2.5,2.5L134.7,57.5z M78.2,128l2.5,2.5l2.5-2.5l-2.5-2.5L78.2,128z M208.2,68l2.5,2.5l2.5-2.5l-2.5-2.5L208.2,68z M25.2,106l2.5,2.5l2.5-2.5l-2.5-2.5L25.2,106z M295.2,151l2.5,2.5l2.5-2.5l-2.5-2.5L295.2,151z"/></svg>'), */
+  background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzMjAiIGhlaWdodD0iMTYwIj48cGF0aCBmaWxsPSJub25lIiBzdHJva2U9IiNGRkZGRkYiIGQ9Ik0yOTYsNTRsLTMyLDEzbC0xOSw1NWwtNTQsMTNsLTI3LTE2IE0yOC43LDMybDEwNiwyMyIvPjxwb2x5Z29uIGZpbGw9IiNGQzZENTEiIHBvaW50cz0iMjkuMiwzNS41IDMyLjcsMzIgMjkuMiwyOC41IDI1LjcsMzIiLz48cGF0aCBmaWxsPSIjZmZmIiBkPSJNMTkxLDEzMi41bC0yLjUsMi41bDIuNSwyLjVsMi41LTIuNUwxOTEsMTMyLjV6IE0xNjQsMTE1LjVsLTMuNSwzLjVsMy41LDMuNWwzLjUtMy41TDE2NCwxMTUuNXpNMjk2LDUxLjVsLTIuNSwyLjVsMi41LDIuNWwyLjUtMi41TDI5Niw1MS41eiBNMjY0LDYyLjVsLTQuNSw0LjVsNC41LDQuNWw0LjUtNC41TDI2NCw2Mi41eiBNMjQ1LDExOC41bC0zLjUsMy41bDMuNSwzLjVsMy41LTMuNUwyNDUsMTE4LjV6IE0xMzQuNyw1Ny41bDIuNS0yLjVsLTIuNS0yLjVsLTIuNSwyLjVMMTM0LjcsNTcuNXogTTc4LjIsMTI4bDIuNSwyLjVsMi41LTIuNWwtMi41LTIuNUw3OC4yLDEyOHogTTIwOC4yLDY4bDIuNSwyLjVsMi41LTIuNWwtMi41LTIuNUwyMDguMiw2OHogTTI1LjIsMTA2bDIuNSwyLjVsMi41LTIuNWwtMi41LTIuNUwyNS4yLDEwNnogTTI5NS4yLDE1MWwyLjUsMi41bDIuNS0yLjVsLTIuNS0yLjVMMjk1LjIsMTUxeiIvPjwvc3ZnPg=='),
   linear-gradient(
     to bottom,
     rgba(12, 21, 47, 0.9),

--- a/theme/jr-west/theme.css
+++ b/theme/jr-west/theme.css
@@ -59,7 +59,8 @@ body {
   align-items: center;
   padding: 0.5rem 0.25rem;
   height: 2.25rem;
-  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="36" height="36"><polygon fill="#fff" points="19,8 12,8 21,16 0,16 0,20 21,20 12,28 19,28 30,18"/></svg>');
+  /* background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="36" height="36"><polygon fill="#fff" points="19,8 12,8 21,16 0,16 0,20 21,20 12,28 19,28 30,18"/></svg>'); */
+  background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiI+PHBvbHlnb24gZmlsbD0iI2ZmZiIgcG9pbnRzPSIxOSw4IDEyLDggMjEsMTYgMCwxNiAwLDIwIDIxLDIwIDEyLDI4IDE5LDI4IDMwLDE4Ii8+PC9zdmc+');
   background-color: hsla(210, 75%, 60%, 1);
   background-color: var(--tint, hsla(210, 75%, 60%, 1));
   background-repeat: no-repeat;
@@ -154,7 +155,8 @@ body {
   width: 2.25rem;
   height: 2.25rem;
 
-  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="36" height="36"><path fill="#0f0" stroke="#fff" stroke-width="1.5" d="M18,17L29.7,5.3C31.3,3.7,30.2,1,28,1H7.8C5.6,1,4.5,3.7,6.1,5.3L18,17zM19,18l11.7,11.7c1.6,1.6,4.3,0.5,4.3-1.8V8c0-2.2-2.7-3.3-4.3-1.8L19,18zM18,19L6.3,30.7C4.7,32.3,5.8,35,8,35H28c2.2,0,3.3-2.7,1.8-4.3L18,19zM17,18L5.3,6.3C3.7,4.7,1,5.8,1,8V28c0,2.2,2.7,3.3,4.3,1.8L17,18z"/></svg>');
+  /* background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="36" height="36"><path fill="#0f0" stroke="#fff" stroke-width="1.5" d="M18,17L29.7,5.3C31.3,3.7,30.2,1,28,1H7.8C5.6,1,4.5,3.7,6.1,5.3L18,17zM19,18l11.7,11.7c1.6,1.6,4.3,0.5,4.3-1.8V8c0-2.2-2.7-3.3-4.3-1.8L19,18zM18,19L6.3,30.7C4.7,32.3,5.8,35,8,35H28c2.2,0,3.3-2.7,1.8-4.3L18,19zM17,18L5.3,6.3C3.7,4.7,1,5.8,1,8V28c0,2.2,2.7,3.3,4.3,1.8L17,18z"/></svg>'); */
+  background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIzNiIgaGVpZ2h0PSIzNiI+PHBhdGggZmlsbD0iIzBmMCIgc3Ryb2tlPSIjZmZmIiBzdHJva2Utd2lkdGg9IjEuNSIgZD0iTTE4LDE3TDI5LjcsNS4zQzMxLjMsMy43LDMwLjIsMSwyOCwxSDcuOEM1LjYsMSw0LjUsMy43LDYuMSw1LjNMMTgsMTd6TTE5LDE4bDExLjcsMTEuN2MxLjYsMS42LDQuMywwLjUsNC4zLTEuOFY4YzAtMi4yLTIuNy0zLjMtNC4zLTEuOEwxOSwxOHpNMTgsMTlMNi4zLDMwLjdDNC43LDMyLjMsNS44LDM1LDgsMzVIMjhjMi4yLDAsMy4zLTIuNywxLjgtNC4zTDE4LDE5ek0xNywxOEw1LjMsNi4zQzMuNyw0LjcsMSw1LjgsMSw4VjI4YzAsMi4yLDIuNywzLjMsNC4zLDEuOEwxNywxOHoiLz48L3N2Zz4=');
 }
 .chat_cheer_text {
   color: #111;
@@ -228,7 +230,8 @@ body {
   height: 5.25rem;
 
   color: #111;
-  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="24"><path fill="#1ce" d="M0,8.7h5.4v6.6c0,1.5,3.7,1.5,4.6,1.5c0.8,0,5.5-0.1,5.5-1.9V0h20.2C39.3,0,40,5.2,40,6.5c0,1.3-0.6,6.9-4,6.9h-2.1l6.1,7.6h-6.8L23.3,8.7h10.2c1.2,0,1.2-1.6,1.2-2c0-0.3-0.1-1.8-1.2-1.8H20.9v11c0,4.8-7.6,5.8-10.5,5.8c-4,0-10.4-1.3-10.4-5.4L0,8.7"/></svg>');
+  /* background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="40" height="24"><path fill="#1ce" d="M0,8.7h5.4v6.6c0,1.5,3.7,1.5,4.6,1.5c0.8,0,5.5-0.1,5.5-1.9V0h20.2C39.3,0,40,5.2,40,6.5c0,1.3-0.6,6.9-4,6.9h-2.1l6.1,7.6h-6.8L23.3,8.7h10.2c1.2,0,1.2-1.6,1.2-2c0-0.3-0.1-1.8-1.2-1.8H20.9v11c0,4.8-7.6,5.8-10.5,5.8c-4,0-10.4-1.3-10.4-5.4L0,8.7"/></svg>'); */
+  background: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MCIgaGVpZ2h0PSIyNCI+PHBhdGggZmlsbD0iIzFjZSIgZD0iTTAsOC43aDUuNHY2LjZjMCwxLjUsMy43LDEuNSw0LjYsMS41YzAuOCwwLDUuNS0wLjEsNS41LTEuOVYwaDIwLjJDMzkuMywwLDQwLDUuMiw0MCw2LjVjMCwxLjMtMC42LDYuOS00LDYuOWgtMi4xbDYuMSw3LjZoLTYuOEwyMy4zLDguN2gxMC4yYzEuMiwwLDEuMi0xLjYsMS4yLTJjMC0wLjMtMC4xLTEuOC0xLjItMS44SDIwLjl2MTFjMCw0LjgtNy42LDUuOC0xMC41LDUuOGMtNCwwLTEwLjQtMS4zLTEwLjQtNS40TDAsOC43Ii8+PC9zdmc+');
   background-color: #eee;
   background-repeat: no-repeat;
   background-size: 2.5rem 1.5rem;


### PR DESCRIPTION
현재 일부 환경에서 utf8로 직접 작성한 inline SVG CSS 속성이 정상적으로 적용되지 않습니다.
따라서 utf8로 작성된 SVG를 모두 base64로 인코딩하여 수정했습니다.
자세한 내용은 아래 링크의 내용을 참조하세요.

https://stackoverflow.com/a/21626701

